### PR TITLE
Resolves issue #361 Updates spelling-mistakes

### DIFF
--- a/_data/learning.yml
+++ b/_data/learning.yml
@@ -93,7 +93,7 @@ reference-links:
     url: https://j3-fortran.org/
     description: J3 is the US National Body for the international Fortran standards committee
   
-  - name: "WG5: International Fortran Standards Committe"
+  - name: "WG5: International Fortran Standards committee"
     url: https://wg5-fortran.org/
     description: 
 


### PR DESCRIPTION
Missing "e" in "WG5: International Fortran Standards Committe" to Missing "e" in "WG5: International Fortran Standards committee"
it might seem a little odd for a spelling mistake but i wanted to contribute.

thanks and regards,
Henil Panchal